### PR TITLE
Adapt the extract img file name with multiple same file types

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -126,8 +126,10 @@ impl Input {
     /// Extract the content of the img files to disk
     pub fn extract_img(&mut self, options: ExtractOptions) -> Result<(), Error> {
         let mut threads = Vec::new();
+        let mut file_index = 0;
         for part in self.img_parts.clone() {
-            let filename = format!("{}.img", part.header.filename()?);
+            file_index += 1;
+            let filename = format!("{}_{}.img", part.header.filename()?, file_index.to_string());
             let offset = part.offset + part.header.headersize();
             let size = part.header.filesize() as usize;
             self.write_to_disk(&filename, offset, size)?;


### PR DESCRIPTION
There are multiple same file types with name 'SUPER' appears in the latest 'UPDATE.APP' file, which is from the HM4 OS. There may be multiple other same file types in the future. So add the extract img file name with the index of the file block can avoid the issue.